### PR TITLE
Bug 437166 - CLA plugin fails if projects can't "Push"

### DIFF
--- a/eclipse-cla/src/main/java/org/eclipse/foundation/gerrit/validation/EclipseCommitValidationListener.java
+++ b/eclipse-cla/src/main/java/org/eclipse/foundation/gerrit/validation/EclipseCommitValidationListener.java
@@ -260,7 +260,7 @@ public class EclipseCommitValidationListener implements CommitValidationListener
 			 */
 			ProjectControl projectControl = projectControlFactory.controlFor(project.getNameKey(), user);
 			RefControl refControl = projectControl.controlForRef("refs/heads/*");
-			return refControl.canUpdate();
+			return refControl.canSubmit();
 		} catch (NoSuchProjectException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();


### PR DESCRIPTION
Currently the CLA Gerrit plugin uses "Push" permissions to assume a person is a committer on a project. However not all projects want to have "Push" enabled into their repos in order to require code review.  This change uses canSubmit() instead, since that permission will be available to committers in the foreseeable future.